### PR TITLE
fix: use env_var_name instead of string to secure sensitive data

### DIFF
--- a/src/commands/@commands.yml
+++ b/src/commands/@commands.yml
@@ -36,13 +36,13 @@ create-release:
     org: &org-parameter
       description: >
         Sentry organization slug.
-      type: string
-      default: $SENTRY_ORG
+      type: env_var_name
+      default: SENTRY_ORG
     project:
       description: >
         Sentry project slug.
-      type: string
-      default: $SENTRY_PROJECT
+      type: env_var_name
+      default: SENTRY_PROJECT
   steps:
     - attach_workspace:
         at: /root

--- a/src/jobs/@jobs.yml
+++ b/src/jobs/@jobs.yml
@@ -22,13 +22,13 @@ create-release:
     org: &org-parameter
       description: >
         Sentry organization slug.
-      type: string
-      default: $SENTRY_ORG
+      type: env_var_name
+      default: SENTRY_ORG
     project:
       description: >
         Sentry project slug.
-      type: string
-      default: $SENTRY_PROJECT
+      type: env_var_name
+      default: SENTRY_PROJECT
   steps:
     - create-release
 finalize-release-set-commits:


### PR DESCRIPTION
CircleCI [best practices](https://circleci.com/docs/2.0/orbs-best-practices/#parameters) suggests to use `env_var_name` to secure  sensitive data.