### PR TITLE
Use config preset for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
-  "extends": ["config:base", "docker:enableMajor"],
-  "labels": ["renovate"],
-  "schedule": ["after 7:00 before 19:00 every weekday"],
-  "timezone": "Europe/Berlin",
-  "circleci": {
-    "fileMatch": ["(^|/).circleci/config.yml$", "(^|/)src/.+\\.yml$"]
-  }
+  "extends": [
+    "github>PicturePipe/renovate-config",
+    "github>PicturePipe/renovate-config:circleci-orb"
+  ]
 }


### PR DESCRIPTION
Instead of duplicating the config of multiple repositories,
we are now using presets which are used in our central renovate
repository.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
