### PR TITLE
fix: bind project var

### DIFF
--- a/src/jobs/@jobs.yml
+++ b/src/jobs/@jobs.yml
@@ -30,7 +30,8 @@ create-release:
       type: env_var_name
       default: SENTRY_PROJECT
   steps:
-    - create-release
+    - create-release:
+        project: << parameters.project >>
 finalize-release-set-commits:
   description: >
     Finalize a Sentry release and set commits. Execute only once per release.


### PR DESCRIPTION
# Bug Fix

### What Is the Current Behavior?
The parameter project for the create-release job just works with default value (SENTRY_PROJECT).

### Steps to Reproduce
Set your .circleci/config.yml: 

```
- sentry-cli/create-release:
          context: sentry-org
          project: SENTRY_PROJECT_NAME
```

Run your job and you will see that `parameters.project` still using SENTRY_PROJECT, that is the default value.

### What Is the Expected Behavior?
When project parameter is filled it should use the new value instead of SENTRY_PROJECT

### Additional Context
It is related to  this issue: https://github.com/PicturePipe/sentry-cli-orb/issues/27

I'm working on a monorepo that have multiple projects, and this is why I need to change the var name used to create releases.

To fix it I'm just binding the project parameter when create-release is called create-release.
